### PR TITLE
Catch exceptions from activities, and fail them back to SWF

### DIFF
--- a/main/Act.hs
+++ b/main/Act.hs
@@ -74,10 +74,6 @@ exec container dockerless uid metadata blobs =
     storeInput $ storeDir </> pack "input"
     dataInput $ dataDir </> pack "input.json"
     maybe (docker dataDir storeDir container) (bash dir container) dockerless
---    if dockerless then
---      bash dir container
---    else
---      docker dataDir storeDir container
     result <- dataOutput $ dataDir </> pack "output.json"
     artifacts <- storeOutput $ storeDir </> pack "output"
     return (result, artifacts) where


### PR DESCRIPTION
When the activity process throws an exception, report it to SWF and keep on trucking.

/cc @scottswift @benjamin0 