### PR TITLE
GZIP artifacts and metadata

### DIFF
--- a/main/Options.hs
+++ b/main/Options.hs
@@ -5,8 +5,7 @@ module Options
   , containerFile
   , queue
   , containerless
-  , gzipMetadata
-  , gzipArtifacts
+  , gzip
   ) where
 
 import BasicPrelude
@@ -59,15 +58,9 @@ containerless =
     <> metavar "DIR"
     <> help    "Run outside of container in directory"
 
-gzipMetadata :: Parser Bool
-gzipMetadata =
+gzip :: Parser Bool
+gzip =
   switch
-    $  long "gzip-metadata"
-    <> help "GZIP contents of metadata"
-
-gzipArtifacts :: Parser Bool
-gzipArtifacts =
-  switch
-    $  long "gzip-artifacts"
+    $  long "gzip"
     <> help "GZIP contents of artifacts"
 

--- a/main/Options.hs
+++ b/main/Options.hs
@@ -5,6 +5,8 @@ module Options
   , containerFile
   , queue
   , containerless
+  , gzipMetadata
+  , gzipArtifacts
   ) where
 
 import BasicPrelude
@@ -56,3 +58,16 @@ containerless =
     $  long    "containerless"
     <> metavar "DIR"
     <> help    "Run outside of container in directory"
+
+gzipMetadata :: Parser Bool
+gzipMetadata =
+  switch
+    $  long "gzip-metadata"
+    <> help "GZIP contents of metadata"
+
+gzipArtifacts :: Parser Bool
+gzipArtifacts =
+  switch
+    $  long "gzip-artifacts"
+    <> help "GZIP contents of artifacts"
+

--- a/wolf.cabal
+++ b/wolf.cabal
@@ -151,6 +151,7 @@ executable wolf-act
                      , transformers
                      , wolf
                      , yaml
+                     , zlib
   default-extensions:  OverloadedStrings
                        RecordWildCards
                        NoImplicitPrelude

--- a/wolf.cabal
+++ b/wolf.cabal
@@ -147,6 +147,7 @@ executable wolf-act
                      , optparse-applicative
                      , resourcet
                      , shelly
+                     , system-filepath
                      , text
                      , transformers
                      , wolf


### PR DESCRIPTION
Pass in options to GZIP artifacts and metadata on behalf of workers. Command line options `gzip-artifacts` and `gzip-metadata` to toggle one or the other. Not currently smart about figuring out if something is already compressed on either side, so will need to be consistent with how this is used.

/cc @scottswift @benjamin0 