### PR TITLE
No copy option + multiple actors

### DIFF
--- a/main/actor.hs
+++ b/main/actor.hs
@@ -16,6 +16,10 @@ data Args = Args
     -- ^ Configuration file.
   , queue   :: Text
     -- ^ Queue to listen to act on.
+  , num     :: Maybe Int
+    -- ^ Number of actors to run concurrently.
+  , nocopy  :: Bool
+    -- ^ Copy working directory.
   , command :: String
     -- ^ Command to run.
   } deriving (Show, Generic)
@@ -30,4 +34,6 @@ main = do
   actMain
     (config args)
     (queue args)
+    (fromMaybe 1 $ num args)
+    (nocopy args)
     (command args)

--- a/src/Network/AWS/Wolf/File.hs
+++ b/src/Network/AWS/Wolf/File.hs
@@ -142,10 +142,11 @@ withCurrentDirectory' wd action =
 
 -- | Setup a temporary work directory and copy current directory files to it.
 --
-withCurrentWorkDirectory :: MonadControl m => Text -> (FilePath -> m a) -> m a
-withCurrentWorkDirectory uid action =
+withCurrentWorkDirectory :: MonadControl m => Text -> Bool -> (FilePath -> m a) -> m a
+withCurrentWorkDirectory uid nocopy action =
   withWorkDirectory uid $ \wd ->
     withCurrentDirectory' wd $ \cd -> do
-      copyDirectoryRecursive cd wd
+      unless nocopy $
+        copyDirectoryRecursive cd wd
       action wd
 


### PR DESCRIPTION
Allow the copy to be disabled - for use cases that don't need their working directory copied. Also add support for running multiple workers for each process.