### PR TITLE
added missing dependencies causing the ambiguous 'Build plan failed.'…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ before_install: mkdir -p $HOME/.local/bin
 install:
   - travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
   - stack config set system-ghc --global true
+  - stack install shake shake-0.16.3
   - pip install --user --upgrade awscli
 
 before_script: rm -rf .build

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ before_install: mkdir -p $HOME/.local/bin
 install:
   - travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
   - stack config set system-ghc --global true
-  - stack install shake-0.16.4
   - pip install --user --upgrade awscli
 
 before_script: rm -rf .build

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install: mkdir -p $HOME/.local/bin
 install:
   - travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
   - stack config set system-ghc --global true
-  - stack install shake shake-0.16.3
+  - stack install shake-0.16.4
   - pip install --user --upgrade awscli
 
 before_script: rm -rf .build

--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ installs plans. See [examples](examples).
 ## Getting started
 1. Install [Haskell](haskell).
 2. Install the Haskell package manager [stack](stack).
-3. Install Lint and Shake:
-    1. `stack install hlint shake`
-4. Setup your global environment:
+3. Setup your global environment:
     1. `mkdir ~/.local/bin` if it doesn't exist already.
     2. add `$HOME/.local/bin` to your `PATH` environment variable.
         - This is usually in `~/.bashrc`, `~/.zshrc`, or similar.
+4. Install build dependencies in the `wolf` stack:
+    1. `stack install hlint shake shakers happy`
 5. Run `stack build`. It should install all dependencies, build binaries, and
    export those binaries to `~/.local/bin`.
 
@@ -50,9 +50,21 @@ installs plans. See [examples](examples).
 
 ## Dependencies
 
-To build, install, run, and test `wolf`, the following dependencies may be required:
+To build, install, run, and test `wolf`, the following (global) dependencies may
+be required:
 
 + [stack][stack]
++ [lint][lint]
++ [shake][shake]
++ [shakers][shakers]
+
+## Common build errors
+
+### "Plan construction failed."
+When building tests using `./Shakefile.hs build-tests-error`, the ambiguous
+`Plan construction failed.` error may rear its head. Make sure your `gcc`
+installation is clean (`brew doctor` may help), and make sure you've installed
+`stack`, `shake`, and `shakers`.
 
 [haskell]:     https://www.haskell.org/platform/
 [wolf]:        https://github.com/swift-nav/wolf
@@ -64,3 +76,6 @@ To build, install, run, and test `wolf`, the following dependencies may be requi
 [deps]:        http://packdeps.haskellers.com/feed?needle=wolf
 [deps-img]:    https://img.shields.io/hackage-deps/v/wolf.svg?style=flat
 [stack]:       https://docs.haskellstack.org/en/stable/README/#how-to-install
+[lint]:        https://hackage.haskell.org/package/hlint
+[stylish]:     https://hackage.haskell.org/package/stylish-haskell
+[shake]:       https://shakebuild.com/

--- a/README.md
+++ b/README.md
@@ -13,11 +13,13 @@ installs plans. See [examples](examples).
 ## Getting started
 1. Install [Haskell](haskell).
 2. Install the Haskell package manager [stack](stack).
-3. Setup your global environment:
+3. Install Lint and Shake:
+    1. `stack install hlint shake`
+4. Setup your global environment:
     1. `mkdir ~/.local/bin` if it doesn't exist already.
     2. add `$HOME/.local/bin` to your `PATH` environment variable.
         - This is usually in `~/.bashrc`, `~/.zshrc`, or similar.
-3. Run `stack build`. It should install all dependencies, build binaries, and
+5. Run `stack build`. It should install all dependencies, build binaries, and
    export those binaries to `~/.local/bin`.
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -72,7 +72,9 @@ be required:
 When building tests using `./Shakefile.hs build-tests-error`, the ambiguous
 `Plan construction failed.` error may rear its head. Make sure your `gcc`
 installation is clean (`brew doctor` may help), and make sure you've installed
-`stack`, `shake`, and `shakers`.
+`stack`, `shake`, and `shakers`. Essentially, what this error is telling you is
+that either `shake` isn't installed, isn't available to the `./Shakefile.hs`, or
+is otherwise broken.
 
 [haskell]:     https://www.haskell.org/platform/
 [wolf]:        https://github.com/swift-nav/wolf

--- a/README.md
+++ b/README.md
@@ -18,9 +18,17 @@ installs plans. See [examples](examples).
     2. add `$HOME/.local/bin` to your `PATH` environment variable.
         - This is usually in `~/.bashrc`, `~/.zshrc`, or similar.
 4. Install build dependencies in the `wolf` stack:
-    1. `stack install hlint shake shakers happy`
+    1. `stack install hlint shake-0.16.4 shakers happy`
 5. Run `stack build`. It should install all dependencies, build binaries, and
    export those binaries to `~/.local/bin`.
+
+Alternatively, read the `.travis.yaml` file.
+
+## Docker getting started
+1. Install [Docker](docker).
+2. Ensure your AWS permissions are current: Docker will build from an
+   intermediate image hosted on swiftnav's AWS ECR.
+3. Run `docker build --rm -t wolf-dev .`
 
 ## Development
 
@@ -79,3 +87,4 @@ installation is clean (`brew doctor` may help), and make sure you've installed
 [lint]:        https://hackage.haskell.org/package/hlint
 [stylish]:     https://hackage.haskell.org/package/stylish-haskell
 [shake]:       https://shakebuild.com/
+[docker]:      https://www.docker.com/get-started

--- a/README.md
+++ b/README.md
@@ -10,6 +10,15 @@ Wolf is a wrapper around Amazon Simple Workflow Service: it providers a decider
 that implements plans, an actor that runs commands, and a registrar that
 installs plans. See [examples](examples).
 
+## Getting started
+1. Install [Haskell](haskell).
+2. Install the Haskell package manager [stack](stack).
+3. Setup your global environment:
+    1. `mkdir ~/.local/bin` if it doesn't exist already.
+    2. add `$HOME/.local/bin` to your `PATH` environment variable.
+        - This is usually in `~/.bashrc`, `~/.zshrc`, or similar.
+3. Run `stack build`. It should install all dependencies, build binaries, and
+   export those binaries to `~/.local/bin`.
 
 ## Development
 
@@ -43,7 +52,7 @@ To build, install, run, and test `wolf`, the following dependencies may be requi
 
 + [stack][stack]
 
-
+[haskell]:     https://www.haskell.org/platform/
 [wolf]:        https://github.com/swift-nav/wolf
 [wolf-img]:    https://cloud.githubusercontent.com/assets/60851/8178609/a077a326-13c4-11e5-9d54-3e417fc6dd6c.jpg
 [hackage]:     https://hackage.haskell.org/package/wolf

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,4 +3,5 @@ packages:
 - .
 extra-deps:
 - preamble-0.0.61
-
+- shake-0.16.4
+- hlint-2.0.11

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,3 +3,4 @@ packages:
 - .
 extra-deps:
 - preamble-0.0.61
+- shake-0.16.4

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,4 +3,3 @@ packages:
 - .
 extra-deps:
 - preamble-0.0.61
-- shake-0.16.4

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,5 +3,3 @@ packages:
 - .
 extra-deps:
 - preamble-0.0.61
-- shake-0.16.4
-- hlint-2.0.11

--- a/wolf.cabal
+++ b/wolf.cabal
@@ -1,5 +1,5 @@
 name:                  wolf
-version:               0.3.45
+version:               0.3.46
 synopsis:              Amazon Simple Workflow Service Wrapper.
 description:           Wolf is a wrapper around Amazon Simple Workflow Service.
 homepage:              https://github.com/swift-nav/wolf


### PR DESCRIPTION
… error raised when running the ./Shakefile.hs previously; Updated the README.md with a beginner-friendly 'getting started' section.