### PR TITLE
Use sync instead of cp

### DIFF
--- a/src/Network/AWS/Wolf/Act.hs
+++ b/src/Network/AWS/Wolf/Act.hs
@@ -23,7 +23,7 @@ import System.Process
 -- | S3 copy call.
 --
 cp :: MonadIO m => [FilePath] -> m ()
-cp = liftIO . callProcess "aws" . (["s3", "cp", "--quiet", "--recursive"] <>)
+cp = liftIO . callProcess "aws" . (["s3", "sync", "--quiet"] <>)
 
 -- | Key to download and upload objects from.
 --


### PR DESCRIPTION
Use sync instead of copy to avoid unnecessary copies. Sync doesn't have a `--recursive` flag - it works recursively by default.