### PR TITLE
Mandatory heartbeating

### DIFF
--- a/main/actor.hs
+++ b/main/actor.hs
@@ -12,29 +12,31 @@ import Options.Generic
 -- Program arguments.
 --
 data Args = Args
-  { config  :: FilePath
+  { config    :: FilePath
     -- ^ Configuration file.
   , storeconf :: Bool
     -- ^ Optional copy configuration file to output dorectory. (default: False)
-  , quiesce :: Maybe FilePath
+  , quiesce   :: Maybe FilePath
     -- ^ Optional quiesce file to stop actor.
-  , domain  :: Maybe Text
+  , domain    :: Maybe Text
     -- ^ Optional domain to use.
-  , bucket  :: Maybe Text
+  , bucket    :: Maybe Text
     -- ^ Optional bucket to use.
-  , prefix  :: Maybe Text
+  , prefix    :: Maybe Text
     -- ^ Optional prefix to use.
-  , queue   :: [Text]
+  , queue     :: [Text]
     -- ^ Queue to listen to act on.
-  , num     :: Maybe Int
+  , num       :: Maybe Int
     -- ^ Number of actors to run concurrently.
-  , nocopy  :: Bool
+  , interval  :: Int
+    -- ^ Interval to heartbeat at.
+  , nocopy    :: Bool
     -- ^ Copy working directory. (default: False)
-  , local   :: Bool
+  , local     :: Bool
     -- ^ Run locally, not in a temp directory. (default: False)
-  , include :: [FilePath]
+  , include   :: [FilePath]
     -- ^ Optional artifacts to filter.
-  , command :: String
+  , command   :: String
     -- ^ Command to run.
   } deriving (Show, Generic)
 
@@ -54,6 +56,7 @@ main = do
     (prefix args)
     (queue args)
     (fromMaybe 1 $ num args)
+    (interval args)
     (nocopy args)
     (local args)
     (include args)

--- a/src/Network/AWS/Wolf/Act.hs
+++ b/src/Network/AWS/Wolf/Act.hs
@@ -75,7 +75,7 @@ run command =
 runHeartbeat :: MonadConf c m => Int -> Text -> FilePath -> m ()
 runHeartbeat interval token msd = do
   traceInfo "heartbeat" mempty
-  let f = (msd </> "heartbeat")
+  let f = msd </> "heartbeat"
   writeText f mempty
   liftIO $ threadDelay $ interval * 1000000
   ok <- liftIO $ doesFileExist f
@@ -107,7 +107,7 @@ act queue nocopy local includes command storeconf interval =
       statsHistogram "wolf.act.poll.elapsed" (realToFrac (diffUTCTime t1 t0) :: Double) [ "queue" =. queue ]
       maybe_ token $ \token' ->
         maybe_ uid $ \uid' ->
-          withCurrentWorkDirectory uid' nocopy local $ \wd -> do
+          withCurrentWorkDirectory uid' nocopy local $ \wd ->
             runAmazonStoreCtx uid' $ do
               traceInfo "start" [ "dir" .= wd ]
               t2   <- liftIO getCurrentTime

--- a/src/Network/AWS/Wolf/SWF.hs
+++ b/src/Network/AWS/Wolf/SWF.hs
@@ -10,6 +10,8 @@ module Network.AWS.Wolf.SWF
   , countDecisions
   , completeActivity
   , failActivity
+  , cancelActivity
+  , heartbeatActivity
   , completeDecision
   , scheduleWork
   , completeWork
@@ -84,6 +86,21 @@ failActivity :: MonadConf c m => Text -> m ()
 failActivity token =
   runResourceT $ runAmazonCtx $
     void $ send $ respondActivityTaskFailed token
+
+-- | Cancel activity.
+--
+cancelActivity :: MonadConf c m => Text -> m ()
+cancelActivity token =
+  runResourceT $ runAmazonCtx $
+    void $ send $ respondActivityTaskCanceled token
+
+-- | Heartbeat activity.
+--
+heartbeatActivity :: MonadConf c m => Text -> m Bool
+heartbeatActivity token =
+  runResourceT $ runAmazonCtx $ do
+    rathrs <- send $ recordActivityTaskHeartbeat token
+    pure (rathrs ^. rathrsCancelRequested)
 
 -- | Successful decision completion.
 --


### PR DESCRIPTION
Add mandatory heartbeating. Wolf will drop a `heartbeat` file in the `meta` directory. The worker must remove the file by the heartbeat interval. Otherwise it's determined to have failed.