### PR TITLE
Updating README to add step to Getting Started section for installing wolf.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ installs plans. See [examples](examples).
     1. `mkdir ~/.local/bin` if it doesn't exist already.
     2. add `$HOME/.local/bin` to your `PATH` environment variable.
         - This is usually in `~/.bashrc`, `~/.zshrc`, or similar.
-3. Run `stack build`. It should install all dependencies, build binaries, and
+3. Run `stack build`. 
+4. Run `./Shakefile.hs install`. It should install all dependencies, build binaries, and
    export those binaries to `~/.local/bin`.
 
 ## Development


### PR DESCRIPTION
Only running 'stack build' did not create binaries and place them in ~/.local/bin. It was only until I ran the './Shakefile.hs install' that resulted in this behavior.