### PR TITLE
Use 'bucket-owner-full-control' when uploading

### DIFF
--- a/src/Network/AWS/Wolf/Act.hs
+++ b/src/Network/AWS/Wolf/Act.hs
@@ -25,7 +25,7 @@ import System.Process
 -- | S3 copy call.
 --
 cp :: MonadIO m => [FilePath] -> m ()
-cp = liftIO . callProcess "aws" . (["s3", "sync", "--quiet"] <>)
+cp = liftIO . callProcess "aws" . (["s3", "sync", "--quiet", "--acl", "bucket-owner-full-control"] <>)
 
 -- | Key to download and upload objects from.
 --


### PR DESCRIPTION
Some recent SITL changes require this acl to be present when you upload to s3.

Could make this optional but seems like it'd normally be desired/fine to have the bucket owner own the files? 