### PR TITLE
make store dir upload/download optional

### DIFF
--- a/src/Network/AWS/Wolf/Types/Product.hs
+++ b/src/Network/AWS/Wolf/Types/Product.hs
@@ -15,7 +15,7 @@ import Network.AWS.Wolf.Prelude
 data Conf = Conf
   { _cDomain :: Text
     -- ^ SWF domain.
-  , _cBucket :: Text
+  , _cBucket :: Maybe Text
     -- ^ S3 bucket.
   , _cPrefix :: Text
     -- ^ S3 prefix.


### PR DESCRIPTION
In order to support transparent compression we want to move wolf's handling of `store/input`/`store/output` into SITL. Not super elegant but I think this should do it. It makes the bucket config optional, when it's not present uploads/downloads are noops