### PR TITLE
Swallow AWS unknown resource exception

### DIFF
--- a/src/Network/AWS/Wolf/Ctx.hs
+++ b/src/Network/AWS/Wolf/Ctx.hs
@@ -143,7 +143,7 @@ swallower action e =
     ServiceError se ->
       bool (throwIO e) (swallowed action) $
         se ^. serviceStatus == badRequest400 &&
-        se ^. serviceCode == "UnknownResource"
+        (se ^. serviceCode == "UnknownResource" || se ^. serviceCode == "Bad Request")
     _ ->
       throwIO e
 

--- a/src/Network/AWS/Wolf/Ctx.hs
+++ b/src/Network/AWS/Wolf/Ctx.hs
@@ -127,7 +127,7 @@ runAmazonWorkCtx queue action = do
   c <- view confCtx <&> cPreamble <>~ preamble
   runTrans (AmazonWorkCtx c queue) (catch action $ throttler action)
 
--- | Swallow bad request exceptions.
+-- | Swallow unknown resource exceptions.
 --
 swallowed :: MonadStatsCtx c m => m a -> m a
 swallowed action = do
@@ -143,7 +143,7 @@ swallower action e =
     ServiceError se ->
       bool (throwIO e) (swallowed action) $
         se ^. serviceStatus == badRequest400 &&
-        se ^. serviceCode == "Bad Request"
+        se ^. serviceCode == "UnknownResource"
     _ ->
       throwIO e
 


### PR DESCRIPTION
Trying to avoid crashes when we get messages of the type

    {
     "event":"exception",
     "time":"2022-01-11T23:49:55.505201528Z",
     "prefix":"sitl-runs",
     "error":"ServiceError (ServiceError' {_serviceAbbrev = Abbrev \"SWF\", _serviceStatus = Status {statusCode = 400, statusMessage = \"Bad Request\"}, _serviceHeaders = [(\"x-amzn-RequestId\",\"aa4e6737-9c06-4567-a509-b8814b3c554d\"),(\"Date\",\"Tue, 11 Jan 2022 23:49:55 GMT\"),(\"Content-Type\",\"application/x-amz-json-1.0\"),(\"Content-Length\",\"215\")], _serviceCode = ErrorCode \"UnknownResource\", _serviceMessage = Just (ErrorMessage \"Unknown execution: WorkflowExecution=[workflowId=4c10390a-d6ea-4339-8232-a2382b6ba5ca, runId=23OadKSpDS3EjISWEK+vnY48cTfKlbg2fB2ej97B6sDyA=]\"), _serviceRequestId = Just (RequestId \"aa4e6737-9c06-4567-a509-b8814b3c554d\")})",
      "domain":"sitl-test",
      "bucket":"sitl-data-test"
    }

from AWS

I think https://github.com/swift-nav/wolf/pull/65 may have been matching on the wrong `serviceCode` string.