### PR TITLE
Some subtle heartbeat bugs [DEVINFRA-958]

### DIFF
--- a/src/Network/AWS/Wolf/Act.hs
+++ b/src/Network/AWS/Wolf/Act.hs
@@ -83,7 +83,7 @@ startHeartbeat queue interval token wd = do
   sd  <- storeDirectory wd
   msd <- metaDirectory sd
   let f = msd </> "heartbeat"
-  writeText f mempty
+  writeText f $ Just ""
   liftIO $ threadDelay $ interval * 1000000
   ok <- check $ pure f
   if ok then do

--- a/src/Network/AWS/Wolf/Act.hs
+++ b/src/Network/AWS/Wolf/Act.hs
@@ -83,7 +83,7 @@ startHeartbeat queue interval token wd = do
   sd  <- storeDirectory wd
   msd <- metaDirectory sd
   let f = msd </> "heartbeat"
-  writeText f $ Just ""
+  writeText f $ Just "HEARTBEAT"
   liftIO $ threadDelay $ interval * 1000000
   ok <- check $ pure f
   if ok then do

--- a/src/Network/AWS/Wolf/Act.hs
+++ b/src/Network/AWS/Wolf/Act.hs
@@ -83,7 +83,7 @@ startHeartbeat queue interval token wd = do
   sd  <- storeDirectory wd
   msd <- metaDirectory sd
   let f = msd </> "heartbeat"
-  writeText f $ Just "HEARTBEAT"
+  writeText f $ pure mempty
   liftIO $ threadDelay $ interval * 1000000
   ok <- check $ pure f
   if ok then do

--- a/src/Network/AWS/Wolf/Act.hs
+++ b/src/Network/AWS/Wolf/Act.hs
@@ -77,8 +77,8 @@ check = maybe (pure False) (liftIO . doesFileExist)
 
 -- | Run a heartbeat.
 --
-startHearbeat :: MonadConf c m => Text -> Int -> Text -> FilePath -> m ()
-startHearbeat queue interval token wd = do
+startHeartbeat :: MonadConf c m => Text -> Int -> Text -> FilePath -> m ()
+startHeartbeat queue interval token wd = do
   traceInfo "heartbeat" mempty
   sd  <- storeDirectory wd
   msd <- metaDirectory sd
@@ -92,7 +92,7 @@ startHearbeat queue interval token wd = do
     statsIncrement "wolf.act.activity.count" [ "queue" =. queue, "status" =. "fail" ]
   else do
     nok <- heartbeatActivity token
-    if not nok then startHearbeat queue interval token wd else do
+    if not nok then startHeartbeat queue interval token wd else do
       traceInfo "cancel" mempty
       cancelActivity token
       statsIncrement "wolf.act.activity.count" [ "queue" =. queue, "status" =. "cancel" ]
@@ -146,7 +146,7 @@ act queue nocopy nos3 local includes command interval =
               unless nos3 $
                 download isd includes
               maybe' interval (startCommand queue nos3 command token' wd) $ \interval' ->
-                race_ (startHearbeat queue interval' token' wd) (startCommand queue nos3 command token' wd)
+                race_ (startHeartbeat queue interval' token' wd) (startCommand queue nos3 command token' wd)
               t3 <- liftIO getCurrentTime
               statsHistogram "wolf.act.activity.elapsed" (realToFrac (diffUTCTime t3 t2) :: Double) [ "queue" =. queue ]
               traceInfo "finish" [ "dir" .= wd ]

--- a/src/Network/AWS/Wolf/Act.hs
+++ b/src/Network/AWS/Wolf/Act.hs
@@ -92,7 +92,7 @@ startHearbeat queue interval token wd = do
     statsIncrement "wolf.act.activity.count" [ "queue" =. queue, "status" =. "fail" ]
   else do
     nok <- heartbeatActivity token
-    if not nok then startHearbeat queue interval token msd else do
+    if not nok then startHearbeat queue interval token wd else do
       traceInfo "cancel" mempty
       cancelActivity token
       statsIncrement "wolf.act.activity.count" [ "queue" =. queue, "status" =. "cancel" ]

--- a/src/Network/AWS/Wolf/File.hs
+++ b/src/Network/AWS/Wolf/File.hs
@@ -71,7 +71,7 @@ metaDirectory dir = do
 --
 writeText :: MonadIO m => FilePath -> Maybe Text -> m ()
 writeText file contents =
-  liftIO $ void $ traverse (writeFile file) contents
+  liftIO $ traverse_ (writeFile file) contents
 
 -- | Maybe read text from a file.
 --


### PR DESCRIPTION
# Context

There are some new jobs running on SITL which run for a very long time (multiple hours).  These jobs are being restarted incorrectly because of a heartbeat timeout event on SWF.  In investigating this issue, I noticed a few subtle bugs in the function `startHeartbeat`, however it is not clear to me that this will actually fix the issues we are seeing in SITL.

`startHeartbeat` should work as follows:

In an infinite loop:
1. write a file to `store/meta/heartbeat`
2. wait `interval` seconds
3. check if the file is still there.  If it is, fail the activity - the sitl job has hung.  If it isn't, call [RecordActivityTaskHeartbeat](https://docs.aws.amazon.com/amazonswf/latest/apireference/API_RecordActivityTaskHeartbeat.html), since the activity is alive.

# Fixes

1. `startHeartbeat` was being called recursively with `msd` (the metastore directory) rather than `wd` (the working directory).  This means that it will first write a file to `store/meta/heartbeat`, then on second pass to `store/meta/store/meta/heartbeat`, then to `store/meta/store/meta/store/meta/heartbeat` and so on.
2. `writeText` was being called with `mempty :: Maybe String` which is `Nothing` (note that for any monoid `m`, `mempty :: Maybe m` is `Nothing`, _not_ `Just mempty`, this is to be consistent with the definition for `m` as a semigroup I think).  This means that it will never write out a file because `traverse f Nothing` does nothing.